### PR TITLE
Parse model path from args and update the link to the model files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-/target
 *.bin
 .DS_Store
+.idea/
+.vscode/
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-agent"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cpal",
  "rubato",
@@ -837,16 +850,17 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs"
-version = "0.5.0"
-source = "git+https://github.com/tazz4843/whisper-rs.git?rev=6e70e56#6e70e56156f9a833ccf95c7ce70e915181e4953a"
+version = "0.6.0"
+source = "git+https://github.com/tazz4843/whisper-rs.git#b5072d486d9d47524afc966784060971820e8275"
 dependencies = [
+ "dashmap",
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.3.2"
-source = "git+https://github.com/tazz4843/whisper-rs.git?rev=6e70e56#6e70e56156f9a833ccf95c7ce70e915181e4953a"
+version = "0.4.0"
+source = "git+https://github.com/tazz4843/whisper-rs.git#b5072d486d9d47524afc966784060971820e8275"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "coreaudio-rs"
@@ -160,7 +160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d959d90e938c5493000514b446987c07aed46c668faaa7d34d6c7a67b1a578c"
 dependencies = [
  "alsa",
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys 0.8.4",
  "coreaudio-rs",
  "dasp_sample",
  "jni 0.19.0",
@@ -278,9 +278,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libloading"
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -687,7 +687,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-agent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cpal",
  "rubato",
@@ -838,17 +838,15 @@ dependencies = [
 [[package]]
 name = "whisper-rs"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7e1b9b003aa3285a0e4469219566266aa1d51ced1be38587251a4f713a1677"
+source = "git+https://github.com/tazz4843/whisper-rs.git?rev=6e70e56#6e70e56156f9a833ccf95c7ce70e915181e4953a"
 dependencies = [
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a389dc665c7354ba6b1982850d4ba05b862907e535708ebdec92cbd9c599e8"
+version = "0.3.2"
+source = "git+https://github.com/tazz4843/whisper-rs.git?rev=6e70e56#6e70e56156f9a833ccf95c7ce70e915181e4953a"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisper-agent"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 cpal = "0.15.2"
 rubato = "0.12.0"
-whisper-rs = { git = "https://github.com/tazz4843/whisper-rs.git", rev = "6e70e56" }
+whisper-rs = { git = "https://github.com/tazz4843/whisper-rs.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisper-agent"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 cpal = "0.15.2"
 rubato = "0.12.0"
-whisper-rs = "0.5.0"
+whisper-rs = { git = "https://github.com/tazz4843/whisper-rs.git", rev = "6e70e56" }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# Whisper agent
+# Whisper Agent
 
-## Download the CLI:
-
+## Installation
+Download any of the models from the [OpenAI HuggingFace page here](https://huggingface.co/ggerganov/whisper.cpp/tree/main)
 ```
-cargo install --git https://github.com/remykarem/whisper-agent whisper-agent
+$ cargo install --git https://github.com/remykarem/whisper-agent whisper-agent
 ```
-
-## Download the ASR model
-
-Download the ggml models from the links found in the Whisper GitHub repo [here](https://github.com/openai/whisper/blob/main/whisper/__init__.py).
 
 ## Usage
+```
+$ whisper-agent <path-to-model>
+```
 
-```
-whisper-agent <path-to-model>
-```
+## TODO
+- Update whisper-rs to 0.6.0 or latest which use generics
+- Upload the package to crates.io for easier installation
+- Add built-in model downloading using reqwest or similar
+- Add a GitHub Actions Workflow to build release binaries
+- Add stream mode to continuously convert speech to words

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,9 +147,11 @@ impl Stt {
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
 
+        let mut state = self.ctx.create_state().expect("failed to create state");
+
         // Run the Whisper ASR model
         println!("Run ASR model");
-        self.ctx
+        state
             .full(params, &self.audio_data[..])
             .expect("failed to run model");
 
@@ -157,11 +159,11 @@ impl Stt {
         self.audio_data.clear();
 
         // Fetch the results
-        let num_segments = self.ctx.full_n_segments();
+        let num_segments = state.full_n_segments().expect("failed to get segments");
 
         (0..num_segments)
             .map(|i| {
-                self.ctx
+                state
                     .full_get_segment_text(i)
                     .expect("failed to get segment")
                     .trim()


### PR DESCRIPTION
I updated `whisper-rs` from `0.5.0` to git commit `6e70e56`, which is the latest version I was able to update to before the generic `K` was added to `WhisperContext`, which I don't understand how to use.

This update allows me to compile the program (or `whisper-rs` library) on Windows natively, but I'm still unable to test the program because of a resampling error that I included as a TODO comment, maybe someone can figure out how to fix that, I've been unable to.

I also updated the link to the model files and added some TODOs to the README for future improvements.